### PR TITLE
Fix middleware import path

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { updateSession } from '@/middleware'
+import { updateSession } from '@/lib/middleware'
 import { type NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary
- fix wrong import path for middleware helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a0b4a814832b81086a1697316490