### PR TITLE
Filter pesquisas by user

### DIFF
--- a/src/app/api/pesquisas/route.ts
+++ b/src/app/api/pesquisas/route.ts
@@ -1,8 +1,23 @@
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
+import { createClient } from "@/lib/server";
 
 export async function GET() {
-  const pesquisas = await prisma.pesquisa.findMany();
-  
-  return NextResponse.json(pesquisas); // Retorna as pesquisas como resposta JSON
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+
+  if (error || !data?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const acessos: { id_pesquisa: string }[] =
+    await prisma.$queryRaw`SELECT id_pesquisa FROM usuario_pesquisa WHERE id_usuario = ${data.user.id}`;
+
+  const pesquisas = await prisma.pesquisa.findMany({
+    where: {
+      id_pesquisa: { in: acessos.map((a) => a.id_pesquisa) },
+    },
+  });
+
+  return NextResponse.json(pesquisas);
 }


### PR DESCRIPTION
## Summary
- restrict `/api/pesquisas` results to logged-in user's entries

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b8af7ebc832b85434f2075796aa7