### PR TITLE
Fix prisma query type mismatch

### DIFF
--- a/src/app/api/pesquisas/route.ts
+++ b/src/app/api/pesquisas/route.ts
@@ -10,8 +10,10 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const acessos: { pesquisa_id: string }[] =
-    await prisma.$queryRaw`SELECT pesquisa_id FROM usuario_pesquisa WHERE usuario_id   = ${data.user.id}`;
+  const acessos = await prisma.usuario_pesquisa.findMany({
+    where: { usuario_id: data.user.id },
+    select: { pesquisa_id: true },
+  });
 
   const pesquisas = await prisma.pesquisa.findMany({
     where: {


### PR DESCRIPTION
## Summary
- avoid raw SQL query to fetch `usuario_pesquisa`

## Testing
- `pnpm lint` *(fails: next not found - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871bcd6f6ec832ba506c1257b6e9592