### PR TITLE
Enable CSV download from sidebar

### DIFF
--- a/src/components/local/appSidebar.tsx
+++ b/src/components/local/appSidebar.tsx
@@ -36,7 +36,7 @@ const data = {
   navMain: [
     {
       title: "Respostas",
-      url: "#",
+      url: "/api/relatorios/respostas",
       icon: FileDownIcon,
     },
     {

--- a/src/components/local/nav-main.tsx
+++ b/src/components/local/nav-main.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -7,7 +9,8 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 import { LucideIcon } from "lucide-react"
-import PesquisaSelect from "./PesquisaSelect" 
+import PesquisaSelect from "./PesquisaSelect"
+import { usePesquisa } from "@/app/context/PesquisaContext"
 
 type NavMainProps = {
   items: {
@@ -18,6 +21,8 @@ type NavMainProps = {
 }
 
 export default function NavMain({ items }: NavMainProps) {
+  const { selectedPesquisa } = usePesquisa();
+
   return (
     <SidebarGroup>
       <SidebarGroupContent className="flex flex-col gap-2">
@@ -31,9 +36,17 @@ export default function NavMain({ items }: NavMainProps) {
         <SidebarMenu>
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton>
-                {item.icon && <item.icon />}
-                <span>{item.title}</span>
+              <SidebarMenuButton asChild>
+                <a
+                  href={
+                    selectedPesquisa
+                      ? `${item.url}?id_pesquisa=${encodeURIComponent(selectedPesquisa)}`
+                      : "#"
+                  }
+                >
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                </a>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}


### PR DESCRIPTION
## Summary
- make `nav-main` a client component so the selected survey can be read
- generate sidebar links with `selectedPesquisa` query param
- update app sidebar data with the answers report route

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728a0a2174832b9c79bd9699685e32