### PR TITLE
Fix TypeScript for forwardRef components

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -98,7 +98,7 @@ const FormControl = React.forwardRef<
 FormControl.displayName = "FormControl"
 
 const FormDescription = React.forwardRef<
-  React.ElementRef<HTMLParagraphElement>,
+  HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => {
   const { formDescriptionId } = useFormField()
@@ -116,7 +116,7 @@ const FormDescription = React.forwardRef<
 FormDescription.displayName = "FormDescription"
 
 const FormMessage = React.forwardRef<
-  React.ElementRef<HTMLParagraphElement>,
+  HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()


### PR DESCRIPTION
## Summary
- adjust forwardRef generics for `FormDescription` and `FormMessage`

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6872975b9e5c832bba8328d22e7e8ab6