### PR TITLE
Fix sidebar user email

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,11 +1,25 @@
 import { AppSidebar } from "@/components/local/appSidebar"
 import { SiteHeader } from "@/components/local/site-header"
-import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { createClient } from "@/lib/server"
+import { redirect } from "next/navigation"
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) {
+    redirect('/auth/login')
+  }
+
+  const user = {
+    name: data.user.user_metadata?.name ?? '',
+    email: data.user.email ?? '',
+    avatar: data.user.user_metadata?.avatar_url ?? '',
+  }
+
   return (
     <SidebarProvider>
-      <AppSidebar variant="inset" />
+      <AppSidebar variant="inset" user={user} />
       <SidebarInset>
         <SiteHeader />
         {children}

--- a/src/components/local/appSidebar.tsx
+++ b/src/components/local/appSidebar.tsx
@@ -27,30 +27,25 @@ import { NavDocuments } from "./nav-documents"
 import { NavUser } from "./nav-user"
 import NavMain from "./nav-main"
 
-const data = {
-  user: {
-    name: "Antonio",
-    email: "antonio@example.com",
-    avatar: "",
+const navMain = [
+  {
+    title: "Respostas",
+    url: "/api/relatorios/respostas",
+    icon: FileDownIcon,
   },
-  navMain: [
-    {
-      title: "Respostas",
-      url: "/api/relatorios/respostas",
-      icon: FileDownIcon,
-    },
-    {
-      title: "Total de caracteres",
-      url: "#",
-      icon: FileDownIcon,
-    },
-    {
-      title: "Questionários",
-      url: "#",
-      icon: FileDownIcon,
-    },
-  ],
-  navClouds: [
+  {
+    title: "Total de caracteres",
+    url: "#",
+    icon: FileDownIcon,
+  },
+  {
+    title: "Questionários",
+    url: "#",
+    icon: FileDownIcon,
+  },
+];
+
+const navClouds = [
     {
       title: "Capture",
       icon: CameraIcon,
@@ -97,8 +92,9 @@ const data = {
         },
       ],
     },
-  ],
-  navSecondary: [
+  ];
+
+const navSecondary = [
     {
       title: "Settings",
       url: "#",
@@ -114,8 +110,9 @@ const data = {
       url: "#",
       icon: SearchIcon,
     },
-  ],
-  documents: [
+  ];
+
+const documents = [
     {
       name: "N8N Workflow",
       url: "#",
@@ -131,10 +128,18 @@ const data = {
       url: "#",
       icon: DatabaseIcon,
     },
-  ],
-}
+];
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+export function AppSidebar({
+  user,
+  ...props
+}: React.ComponentProps<typeof Sidebar> & {
+  user: {
+    name: string
+    email: string
+    avatar: string
+  }
+}) {
 
   return (
     <Sidebar collapsible="offcanvas" {...props}>
@@ -150,12 +155,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
-        <NavDocuments items={data.documents} />
+        <NavMain items={navMain} />
+        <NavDocuments items={documents} />
         {/* <NavSecondary items={data.navSecondary} className="mt-auto" /> */}
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        <NavUser user={user} />
       </SidebarFooter>
     </Sidebar>
   )


### PR DESCRIPTION
## Summary
- fetch current user in dashboard layout
- pass the user to `AppSidebar`
- adjust `AppSidebar` to display provided user data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a0c43354832b8b0c7b70ee91368b