### PR TITLE
Add responsive container to dashboard

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -21,8 +21,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
     <SidebarProvider>
       <AppSidebar variant="inset" user={user} />
       <SidebarInset>
-        <SiteHeader />
-        {children}
+        <div className="mx-auto flex w-full max-w-7xl flex-col px-4 md:px-6">
+          <SiteHeader />
+          {children}
+        </div>
       </SidebarInset>
     </SidebarProvider>
   )

--- a/src/components/local/site-header.tsx
+++ b/src/components/local/site-header.tsx
@@ -4,7 +4,7 @@ import { SidebarTrigger } from "@/components/ui/sidebar"
 export function SiteHeader() {
   return (
     <header className="group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear">
-      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+      <div className="flex w-full items-center gap-1">
         <SidebarTrigger className="-ml-1" />
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
         <h1 className="text-base font-medium">DashBoard</h1>


### PR DESCRIPTION
## Summary
- center Dashboard layout within a `max-w-7xl` container
- remove padding from `SiteHeader` so container spacing is applied

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2b130d28832bb63771a0e4ba236f